### PR TITLE
Add Git Commit Highlighting

### DIFF
--- a/colors/moonfly.vim
+++ b/colors/moonfly.vim
@@ -400,6 +400,14 @@ exec "highlight DiffChange ctermbg=236 guibg=" . s:grey236
 exec "highlight DiffDelete ctermbg=236 guibg=" . s:grey236 . " ctermfg=251 guifg=fg gui=none"
 exec "highlight DiffText ctermbg=4 guibg=" . s:blue . " ctermfg=bg guifg=bg gui=none"
 
+" For Git Commits.
+exec "highlight gitCommitBranch ctermfg=12 guifg=" . s:light_blue
+exec "highlight gitCommitHeader ctermfg=13 guifg=" . s:purple
+exec "highlight gitCommitSelectedFile ctermfg=10 guifg=" . s:emerald
+exec "highlight gitCommitSelectedType ctermfg=12 guifg=" . s:light_blue
+exec "highlight gitCommitDiscardedFile ctermfg=9 guifg=" . s:crimson
+exec "highlight gitCommitDiscardedType ctermfg=12 guifg=" . s:light_blue
+
 " For vim files.
 exec "highlight vimBracket ctermfg=12 guifg=" . s:light_blue
 exec "highlight vimCommand ctermfg=7 guifg=" . s:orange


### PR DESCRIPTION
Adds highlighting rules for git commits. The main desire is to differentiate staged and unstaged files with the filenames of staged files highlighted in green and unstaged files highlighted in red. 

Color Mappings:
- Staged filenames: Emerald
- Unstaged filenames: Crimson
- Branch name: Light Blue
- Heading text: Purple
- 'modified' text: Light Blue

Feel free to modify these as you see fit.