### PR TITLE
Adds missing equal sign.

### DIFF
--- a/colors/moonfly.vim
+++ b/colors/moonfly.vim
@@ -705,7 +705,7 @@ exec "highlight diffLine ctermfg=12 guifg=" . s:sky
 exec "highlight diffRemoved ctermfg=1 guifg=" . s:red
 exec "highlight diffSubname ctermfg=12 guifg=" . s:sky
 if g:moonflyUnderlineMatchParen
-    exec "highlight MatchWord cterm=underline gui=underline guisp" . s:coral
+    exec "highlight MatchWord cterm=underline gui=underline guisp=" . s:coral
 else
     exec "highlight MatchWord ctermfg=8 guifg=" . s:coral
 endif


### PR DESCRIPTION
Plugin shows error on load when `moonflyUnderlineMatchParen` option is
enabled due to missing equal sign.