### PR TITLE
Fix: terminal_color_6

### DIFF
--- a/colors/moonfly.vim
+++ b/colors/moonfly.vim
@@ -71,7 +71,7 @@ if g:moonflyTerminalColors
         let g:terminal_color_3  = '#e3c78a'
         let g:terminal_color_4  = '#80a0ff'
         let g:terminal_color_5  = '#d183e8'
-        let g:terminal_color_7  = '#79dac8'
+        let g:terminal_color_6  = '#79dac8'
         let g:terminal_color_7  = '#b2b2b2'
         let g:terminal_color_8  = '#949494'
         let g:terminal_color_9  = '#ff5189'


### PR DESCRIPTION
I was writing a function to extract terminal colors from colorschemes when I noticed that `g:terminal_color_6` was missing. I assume this was a type and created a PR.