### PR TITLE
Add `NeoTreeGitAdded` highlight link

### DIFF
--- a/colors/moonfly.vim
+++ b/colors/moonfly.vim
@@ -980,6 +980,7 @@ if has('nvim')
     highlight! link NeoTreeGitConflict MoonflyCrimson
     highlight! link NeoTreeGitModified MoonflyViolet
     highlight! link NeoTreeGitUntracked MoonflyGrey241
+    highlight! link NeoTreeGitAdded MoonflyGreen
     highlight! link NeoTreeMessage MoonflyGrey247
     highlight! link NeoTreeModified MoonflyYellow
     highlight! link NeoTreeRootName MoonflyPurple


### PR DESCRIPTION
Moonfly doesn't explicitly set a highlight for `NeoTreeGitAdded`, and it appears to be defaulting to `MoonflyEmerald` for the foreground colour, but the background colour is not correct when the tree item is highlighted. Setting an explicit highlight fixes this.

Before:
![image](https://user-images.githubusercontent.com/5663042/197675901-27611179-9c08-4428-a00a-e89b41c33ed8.png)

After:
![image](https://user-images.githubusercontent.com/5663042/197676207-5c36ada9-ba82-4c5f-bc72-e957db216f86.png)

