### PR TITLE
Fix Installation with vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ manager.
 [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```viml
-Plug 'bluz71/vim-moonfly-colors', , { 'as': 'moonfly' }
+Plug 'bluz71/vim-moonfly-colors', { 'as': 'moonfly' }
 ```
 
 [packer.nvim](https://github.com/wbthomason/packer.nvim):


### PR DESCRIPTION
Hello there. I'm using this color scheme but something went wrong when I follow the install instruction in README.
Although I'm new to vim, these two commas doesn't make sense to me. I simply delete one and everything works.
I think this might be a "bug", and I'm creating my very first pull request. Ha Ha.

---

你好呀。我最近在使用这款颜色主题，但是当我照着README文件中的安装指示操作时，貌似出现了一点问题。
尽管我刚刚才开始使用vim，这两个紧挨在一起的逗号我感觉完全说不通。我把它们删掉之后，一切都正常了。
我觉得这可能是一个“小问题”，于是我开了我的第一个Pull Request。嘿嘿~