### PR TITLE
feat(extras): add wezterm color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,20 @@ A collection of _moonfly_-flavoured themes are provided:
   [this](extras/windows-terminal-settings.json) theme into their `settings.json`
   configuration
 
+- [WezTerm](https://wezfurlong.org/wezterm) users can copy
+  [this](extras/moonfly-wezterm.toml) theme into the `colors` directory and
+  then specify it though:
+
+  ```lua
+  config.color_scheme = "moonfly"
+  ```
+  
+  The `colors` directory is in one of these places:
+  * `$XDG_CONFIG_HOME/wezterm/colors` (X11/Wayland)
+  * `$HOME/.config/wezterm/` (Windows)
+  * The same directory as the wezterm.exe binary
+  * Any directory configured in `config.color_scheme_dirs`
+
 For other terminals please configure appropriately with the following colors:
 
 | Type           | Category        | Value     | Color

--- a/extras/moonfly-wezterm.toml
+++ b/extras/moonfly-wezterm.toml
@@ -1,0 +1,64 @@
+# Reference: https://wezfurlong.org/wezterm/config/appearance.html#defining-your-own-colors
+[colors]
+# The default text color
+foreground = '#bdbdbd'
+# The default background color
+background = '#080808'
+
+# Overrides the text color when the current cell is occupied by the cursor
+cursor_fg = '#080808'
+# Overrides the cell background color when the current cell is occupied by the
+# cursor and the cursor style is set to Block
+cursor_bg = '#9e9e9e'
+# Specifies the border color of the cursor when the cursor style is set to Block,
+# or the color of the vertical or horizontal bar when the cursor style is set to
+# Bar or Underline.
+cursor_border = '#9e9e9e'
+
+# the foreground color of selected text
+selection_fg = '#080808'
+# the background color of selected text
+selection_bg = '#b2ceee'
+
+# The color of the scrollbar "thumb"; the portion that represents the current viewport
+scrollbar_thumb = '#9e9e9e'
+
+# The color of the split lines between panes
+split = '#9e9e9e'
+
+ansi = [
+  '#323437',
+  '#ff5454',
+  '#8cc85f',
+  '#e3c78a',
+  '#80a0ff',
+  '#cf87e8',
+  '#79dac8',
+  '#c6c6c6',
+]
+brights = [
+  '#949494',
+  '#ff5189',
+  '#36c692',
+  '#c2c292',
+  '#74b2ff',
+  '#ae81ff',
+  '#85dc85',
+  '#e4e4e4',
+]
+
+# Since: 20220319-142410-0fcdea07
+# When the IME, a dead key or a leader key are being processed and are effectively
+# holding input pending the result of input composition, change the cursor
+# to this color to give a visual cue about the compose state.
+compose_cursor = '#e3c78a'
+
+# When the BEL ascii sequence is sent to a pane, the bell is "rung" in that pane with this color
+# For more information and configuration, see:
+# https://wezfurlong.org/wezterm/config/lua/config/visual_bell.html
+visual_bell = '#e3c78a'
+
+[metadata]
+name = 'moonfly'
+origin_url = 'https://github.com/bluz71/vim-moonfly-colors'
+


### PR DESCRIPTION
Added toml file for wezterm.

`[colors.tab_bar]` sections are not included because the parameters are somewhat unique to wezterm compared to other terminals, and I'm not sure what colors to map.