### PR TITLE
Add CocSemTypeBuiltin -> MoonflyCranberry to moonfly which is same as neovim

### DIFF
--- a/autoload/moonfly.vim
+++ b/autoload/moonfly.vim
@@ -681,6 +681,7 @@ function! moonfly#Style() abort
     highlight! link CocSemTypeRegexp MoonflyTurquoise
     highlight! link CocSemTypeStruct MoonflyEmerald
     highlight! link CocSemTypeTypeParameter MoonflyOrchid
+    highlight! link CocSemTypeBuiltin MoonflyCranberry
     highlight! link CocUnusedHighlight MoonflyGrey70
     exec 'highlight CocInlayHint guibg=' . s:grey11 . ' guifg=' . s:grey58
 

--- a/lua/moonfly/init.lua
+++ b/lua/moonfly/init.lua
@@ -833,6 +833,7 @@ M.style = function()
   highlight(0, "CocSemTypeRegexp", { link = "MoonflyTurquoise" })
   highlight(0, "CocSemTypeStruct", { link = "MoonflyEmerald" })
   highlight(0, "CocSemTypeTypeParameter", { link = "MoonflyOrchid" })
+  highlight(0, "CocSemTypeBuiltin", { link = "MoonflyCranberry" })
   highlight(0, "CocUnusedHighlight", { link = "MoonflyGrey70" })
 
   -------------------------------------------------------------------------


### PR DESCRIPTION
Hi thx for your effort. This is just quick addition of `CocSemTypeBuiltin` highlight.
Previously it highlights as a `keyword` which is same with pub, fn, const etc. (first line `@import`)
![image](https://github.com/bluz71/vim-moonfly-colors/assets/90291236/684a75b2-8770-4e85-901d-695a4ccc664c)

now it matches
![image](https://github.com/bluz71/vim-moonfly-colors/assets/90291236/48189d17-9057-44b1-ada9-7e568a42610a)

