### PR TITLE
README: add blink.cmp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,16 @@ require('cmp').setup({
 })
 ```
 
+:bulb: Similarly [blink.cmp](https://github.com/Saghen/blink.cmp)] may be configured like so:
+```lua
+local winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel"
+require("blink.cmp").setup({
+  completion = {
+    menu = { winhighlight = winhighlight },
+    documentation = { window = { winhighlight = winhighlight } },
+  },
+})```
+
 ---
 
 ### moonflyTerminalColors


### PR DESCRIPTION
To match the nvim-cmp example
before:
![image](https://github.com/user-attachments/assets/8bd91d60-7449-4c9c-8125-1b182c61fddc)
after:
![image](https://github.com/user-attachments/assets/5d9b9b12-0574-46cf-b5ae-2db806881565)

