### PR TITLE
fix(lualine): add missing modes for `terminal`

### DIFF
--- a/lua/lualine/themes/moonfly.lua
+++ b/lua/lualine/themes/moonfly.lua
@@ -36,6 +36,10 @@ return {
     a = {fg = colors.color6, bg = colors.color2},
     b = {fg = colors.color2, bg = colors.color0}
   },
+  terminal = {
+    a = { fg = colors.color6, bg = colors.color2 },
+    b = { fg = colors.color2, bg = colors.color0 }
+  },
   visual = {
     a = {fg = colors.color6, bg = colors.color3},
     b = {fg = colors.color3, bg = colors.color0}


### PR DESCRIPTION
When using the `use_mode_colors = true` option for the window/tab components in lualine, the sections `b` and `y` may not display the correct colors in terminal mode due to the absence of color definitions within the theme script. Resulting in the highlight group, e.g. `lualine_b_command` being initialized with default (cleared) value.

While this issue might be related to how lualine handles highlight groups, the simplest solution is to add the missing mode configurations directly in the theme.

This simply copies the insert mode table to a new table called `terminal` with the same color values.

---

###### Previous version: (inside terminal mode, shows improper highlights)
![Gg1dEWEU2E](https://github.com/user-attachments/assets/2916fdba-fe24-4cf1-b339-5ef749fadc65)

###### Terminal mode (after applying this patch):
![rjr7ejFCdC](https://github.com/user-attachments/assets/fcf55002-7d40-4511-b280-1d208ba29f64)
