### PR TITLE
extras/tmux: remove trailing slash

### DIFF
--- a/extras/moonfly.tmux
+++ b/extras/moonfly.tmux
@@ -19,4 +19,4 @@ setw -g window-status-format " #I  #W #[fg=#e65e72]#{?window_flags,#{window_f
 set -g status-left "#[fg=#f09479]⠶ #[fg=#80a0ff]#S@#h "
 if-shell '[[ $(uname) = Darwin ]]' \
     'set -g status-right "%a %d %b  #[fg=#80a0ff]%I:%M%p"' \
-    'set -g status-right "%a %d %b  #[fg=#80a0ff]%I:%M%P"' \
+    'set -g status-right "%a %d %b  #[fg=#80a0ff]%I:%M%P"'


### PR DESCRIPTION
This continues the conditional onto the next line, which will cause errors if there's something on the line after this.