### PR TITLE
Fixed incorrect access of slate in custom_colors

### DIFF
--- a/lua/moonfly/init.lua
+++ b/lua/moonfly/init.lua
@@ -1477,7 +1477,7 @@ M.custom_colors = function(colors)
   red = colors.red and colors.red or M.palette.red
   mineral = colors.mineral and colors.mineral or M.palette.mineral
   bay = colors.bay and colors.bay or M.palette.bay
-  slate = colors.slate and colors.slate or M.slate.bay
+  slate = colors.slate and colors.slate or M.palette.slate
 end
 
 return M


### PR DESCRIPTION
After I updated the color scheme I got this error:

```
E5113: Error while calling lua chunk: ...nvim/site/pack/packer/start/moonfly/lua/moonfly/init.lua:1480: attempt to index field 'slate' (a nil value)
stack traceback:
        ...nvim/site/pack/packer/start/moonfly/lua/moonfly/init.lua:1480: in function 'custom_colors'
        .../after/plugin/colorscheme.lua:7: in main chunk
```