### PR TITLE
new option vim.g.moonflySpellErrorColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ let g:lightline = { 'colorscheme': 'moonfly' }
 | [moonflyUndercurls](https://github.com/bluz71/vim-moonfly-colors#moonflyundercurls)                   | Enabled
 | [moonflyUnderlineMatchParen](https://github.com/bluz71/vim-moonfly-colors#moonflyunderlinematchparen) | Disabled
 | [moonflyVirtualTextColor](https://github.com/bluz71/vim-moonfly-colors#moonflyvirtualtextcolor)       | Disabled
+| [moonflySpellErrorColor](https://github.com/bluz71/vim-moonfly-colors#moonflyspellerrorcolor)         | Enabled
 | [moonflyWinSeparator](https://github.com/bluz71/vim-moonfly-colors#moonflywinseparator)               | `1`
 
 ---
@@ -310,6 +311,25 @@ vim.g.moonflyVirtualTextColor = true
 ```vim
 " Vimscript initialization file
 let g:moonflyVirtualTextColor = v:true
+```
+
+---
+
+### moonflySpellErrorColor
+
+The `moonflySpellErrorColor` option specifies whether to display spelling
+errors in color. By default this option is **enabled**. Note, if undercurls are
+enabled, then this option is ignored. If you prefer not to display spelling
+errors in color then add the following to your initialization file:
+
+```lua
+-- Lua initialization file
+vim.g.moonflySpellErrorColor = false
+```
+
+```vim
+" Vimscript initialization file
+let g:moonflySpellErrorColor = v:false
 ```
 
 ---

--- a/autoload/moonfly.vim
+++ b/autoload/moonfly.vim
@@ -228,11 +228,16 @@ function! moonfly#Style() abort
         exec 'highlight SpellCap ctermbg=NONE cterm=underline guibg=NONE gui=undercurl guisp=' . s:yellow
         exec 'highlight SpellRare ctermbg=NONE cterm=underline guibg=NONE gui=undercurl guisp=' . s:green
         exec 'highlight SpellLocal ctermbg=NONE cterm=underline guibg=NONE gui=undercurl guisp=' . s:sky
-    else
+    elseif g:moonflySpellErrorColor
         exec 'highlight SpellBad ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:red . ' gui=underline guisp=' . s:red
         exec 'highlight SpellCap ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:yellow . ' gui=underline guisp=' . s:yellow
         exec 'highlight SpellRare ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:green . ' gui=underline guisp=' . s:green
         exec 'highlight SpellLocal ctermbg=NONE cterm=underline guibg=NONE guifg=' . s:sky . ' gui=underline guisp=' . s:sky
+    else
+        exec 'highlight SpellBad ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:red
+        exec 'highlight SpellCap ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:yellow
+        exec 'highlight SpellRare ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:green
+        exec 'highlight SpellLocal ctermbg=NONE cterm=underline guibg=NONE gui=underline guisp=' . s:sky
     endif
 
     " Misc

--- a/colors/moonfly.vim
+++ b/colors/moonfly.vim
@@ -29,6 +29,7 @@ let g:moonflyTransparent = get(g:, 'moonflyTransparent', v:false)
 let g:moonflyUndercurls = get(g:, 'moonflyUndercurls', v:true)
 let g:moonflyUnderlineMatchParen = get(g:, 'moonflyUnderlineMatchParen', v:false)
 let g:moonflyVirtualTextColor =  get(g:, 'moonflyVirtualTextColor', v:false)
+let g:moonflySpellErrorColor =  get(g:, 'moonflySpellErrorColor', v:true)
 let g:moonflyWinSeparator = get(g:, 'moonflyWinSeparator', 1)
 
 if has('nvim')

--- a/doc/moonfly.txt
+++ b/doc/moonfly.txt
@@ -12,6 +12,7 @@ Default option values:
   let g:moonflyUndercurls = v:true
   let g:moonflyUnderlineMatchParen = v:false
   let g:moonflyVirtualTextColor = v:false
+  let g:moonflySpellErrorColor = v:true
   let g:moonflyWinSeparator = 1
 <
 ------------------------------------------------------------------------------
@@ -126,6 +127,20 @@ initialization file:
 
   " Vimscript initialization file
   let g:moonflyVirtualTextColor = v:true
+<
+------------------------------------------------------------------------------
+moonflySpellErrorColor~                             *g:moonflySpellErrorColor*
+
+The `moonflySpellErrorColor` option specifies whether to display spelling
+errors in color. By default this option is **enabled**. Note, if undercurls
+are enabled, then this option is ignored. If you prefer not to display
+spelling errors in color then add the following to your initialization file:
+>
+  -- Lua initialization file
+  vim.g.moonflySpellErrorColor = false
+
+  " Vimscript initialization file
+  let g:moonflySpellErrorColor = v:false
 <
 ------------------------------------------------------------------------------
 moonflyWinSeparator~                                   *g:moonflyWinSeparator*

--- a/doc/moonfly.txt
+++ b/doc/moonfly.txt
@@ -11,6 +11,7 @@ Default option values:
   let g:moonflyTransparent = v:false
   let g:moonflyUndercurls = v:true
   let g:moonflyUnderlineMatchParen = v:false
+  let g:moonflyVirtualTextColor = v:false
   let g:moonflyWinSeparator = 1
 <
 ------------------------------------------------------------------------------

--- a/doc/moonfly.txt
+++ b/doc/moonfly.txt
@@ -1,6 +1,6 @@
 *moonfly* A dark charcoal theme for classic Vim & modern Neovim.
 
-OPTIONS                                                       *moonfly-options*
+OPTIONS                                                      *moonfly-options*
 
 Default option values:
 >

--- a/lua/moonfly/init.lua
+++ b/lua/moonfly/init.lua
@@ -290,11 +290,16 @@ M.style = function()
     highlight(0, "SpellCap", { bg = none, undercurl = true, sp = yellow })
     highlight(0, "SpellRare", { bg = none, undercurl = true, sp = green })
     highlight(0, "SpellLocal", { bg = none, undercurl = true, sp = sky })
-  else
+  elseif g.moonflySpellErrorColor then
     highlight(0, "SpellBad", { bg = none, fg = red, underline = true, sp = red })
     highlight(0, "SpellCap", { bg = none, fg = yellow, underline = true, sp = yellow })
     highlight(0, "SpellRare", { bg = none, fg = green, underline = true, sp = green })
     highlight(0, "SpellLocal", { bg = none, fg = sky, underline = true, sp = sky })
+  else
+    highlight(0, "SpellBad", { bg = none, underline = true, sp = red })
+    highlight(0, "SpellCap", { bg = none, underline = true, sp = yellow })
+    highlight(0, "SpellRare", { bg = none, underline = true, sp = green })
+    highlight(0, "SpellLocal", { bg = none, underline = true, sp = sky })
   end
 
   -- Misc


### PR DESCRIPTION
The addition of this option is motivated by the behavior of moonflyUndercurls.

When moonflyUndercurls is enabled, which is the default:
- undercurls are used for spelling and linting errors

However, when moonflyUndercurls is disabled:
- underlining is used for spelling and linting errors, and
- spelling errors are highlighted by setting the foreground color

The new option moonflySpellErrorColor can be used to disable the highlighting of spelling errors via foreground color. By default this option is enabled, i.e., underlined spelling errors are also colored.

Note, this new option can NOT be used to enable the highlighting of spelling errors via foreground color when moonflyUndercurls is enabled. Since the default for moonflySpellErrorColor is enabled to maintain current behavior for underlining, doing so would break current behavior for undercurls.

Miscellaneous commits:
- doc: adhere to text width
- doc: add missing default option value